### PR TITLE
Adding missing Unicode blocks

### DIFF
--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -88,6 +88,7 @@
   \do{DominoTiles}{127024}{127135}
   \do{EnclosedAlphanumerics}{9312}{9471}
   \do{EnclosedCJKLettersAndMonths}{12800}{13055}
+  \do{EgyptianHieroglyphs}{77824}{81919}
   \do{Ethiopic}{4608}{4991}
   \do{EthiopicExtended}{11648}{11743}
   \do{EthiopicSupplement}{4992}{5023}
@@ -109,6 +110,7 @@
   \do{Hebrew}{1424}{1535}
   \do{Hiragana}{12352}{12447}
   \do{IdeographicDescriptionCharacters}{12272}{12287}
+  \do{ImperialAramaic}{67648}{67679}
   \do{IPAExtensions}{592}{687}
   \do{Kanbun}{12688}{12703}
   \do{KangxiRadicals}{12032}{12255}
@@ -425,6 +427,7 @@
   \do{Dingbats}
   \do{DominoTiles}
   \do{EnclosedAlphanumerics}
+  \do{EgyptianHieroglyphs}
   \do{Ethiopic}
   \do{EthiopicExtended}
   \do{EthiopicSupplement}
@@ -436,6 +439,7 @@
   \do{Gurmukhi}
   \do{Hanunoo}
   \do{Hebrew}
+  \do{ImperialAramaic}
   \do{Kannada}
   \do{Kharoshthi}
   \do{Khmer}

--- a/ucharclasses.tex
+++ b/ucharclasses.tex
@@ -354,6 +354,7 @@
 				\item DominoTiles
 				\item EnclosedAlphanumerics
 				\item EnclosedCJKLettersandMonths
+				\item EgyptianHieroglyphs
 				\item Ethiopic
 				\item EthiopicExtended
 				\item EthiopicSupplement
@@ -375,6 +376,7 @@
 				\item Hebrew
 				\item Hiragana
 				\item IdeographicDescriptionCharacters
+				\item ImperialAramaic
 				\item IPAExtensions
 				\item Kanbun
 				\item KangxiRadicals


### PR DESCRIPTION
Current version of ucharclasses misses EgyptianHieroglyphs and
ImperialAramaic blocks (maybe more?).

Documentation source should be sufficiently amended, but I don't have
the proper font files for generating the pdf.