### PR TITLE
Unicode 10.0

### DIFF
--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -80,7 +80,7 @@
   \do{Buginese}{"01A00}{"01A1F}
   \do{Buhid}{"01740}{"0175F}
   \do{ByzantineMusicalSymbols}{"01D000}{"01D0FF}
-  \do{Carian}{"0102A0}{"0102DF}
+%     Carian (see below)
   \do{Cham}{"0AA00}{"0AA5F}
   \do{Cherokee}{"013A0}{"013FF}
   \do{CJKCompatibility}{"03300}{"033FF}
@@ -310,7 +310,7 @@
   \do{WarangCiti}{"0118A0}{"0118FF}
 % Unicode 8.0 additions
   \do{Ahom}{"011700}{"01173F}
-  \do{AnatolianHieroglyphs}{"014400}{"01467F}
+%     AnatolianHieroglyphs (see below)
   \do{CherokeeSupplement}{"0AB70}{"0ABBF}
   \do{CJKUnifiedIdeographsExtensionE}{"02B820}{"02CEAF}
   \do{EarlyDynasticCuneiform}{"012480}{"01254F}
@@ -328,6 +328,8 @@
 %     SuttonSignWriting (see below)
 %
   \ifdefined\XeTeXinterwordspaceshaping
+    \do{AnatolianHieroglyphs}{"014400}{"01467F}
+    \do{Carian}{"0102A0}{"0102DF}
     \do{Duployan}{"01BC00}{"01BC9F}
     \do{OldItalic}{"010300}{"01032F}
     \do{OldNorthArabian}{"010A80}{"010A9F}
@@ -616,7 +618,7 @@
 \def\OtherClasses{
   \do{AegeanNumbers}
   \do{Ahom}
-  \do{AnatolianHieroglyphs}
+%     AnatolianHieroglyphs (see below)
   \do{AncientGreekMusicalNotation}
   \do{AncientGreekNumbers}
   \do{AncientSymbols}
@@ -633,7 +635,7 @@
   \do{BraillePatterns}
   \do{Buginese}
   \do{Buhid}
-  \do{Carian}
+%     Carian (see below)
   \do{Cham}
   \do{CaucasianAlbanian}
   \do{Chakma}
@@ -763,7 +765,9 @@
 %
   \ifdefined\XeTeXinterwordspaceshaping
     \do{Adlam}
+    \do{AnatolianHieroglyphs}
     \do{Bhaiksuki}
+    \do{Carian}
     \do{Duployan}
     \do{Marchen}
     \do{MasaramGondi}

--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -318,14 +318,16 @@
   \do{Multani}{"011280}{"0112AF}
   \do{OldHungarian}{"010C80}{"010CFF}
   \do{SupplementalSymbolsAndPictographs}{"01F900}{"01F9FF}
+%     SuttonSignWriting (see below)
 % Unicode 9.0 additions needed for classes
   \do{CyrillicExtendedC}{"01C80}{"01C8F}
   \do{GlagoliticSupplement}{"01E000}{"01E02F}
   \do{IdeographicSymbolsAndPunctuation}{"016FE0}{"016FFF}
+  \do{MongolianSupplement}{"011660}{"01167F}
 % Unicode 10.0 additions needed for classes
   \do{CJKUnifiedIdeographsExtensionF}{"02CEB0}{"02EBEF}
   \do{KanaExtendedA}{"01B100}{"01B12F}
-%     SuttonSignWriting (see below)
+  \do{SyriacSupplement}{"0860}{"086F}
 %
   \ifdefined\XeTeXinterwordspaceshaping
     \do{AnatolianHieroglyphs}{"014400}{"01467F}
@@ -344,7 +346,6 @@
     \do{Adlam}{"01E900}{"01E95F}
     \do{Bhaiksuki}{"011C00}{"011C6F}
     \do{Marchen}{"011C70}{"011CBF}
-    \do{MongolianSupplement}{"011660}{"01167F}
     \do{Newa}{"011400}{"01147F}
     \do{Osage}{"0104B0}{"0104FF}
     \do{Tangut}{"017000}{"0187FF}
@@ -353,7 +354,6 @@
     \do{MasaramGondi}{"011D00}{"011D5F}
     \do{Nushu}{"01B170}{"01B2FF}
     \do{Soyombo}{"011A50}{"011AAF}
-    \do{SyriacSupplement}{"0860}{"086F}
     \do{ZanabazarSquare}{"011A00}{"011A4F}
   \fi
 }
@@ -396,11 +396,13 @@
   \doclass{Japanese}
   \doclass{Latin}
   \doclass{Mathematics}
+  \doclass{MongolianFull}
   \doclass{MyanmarFull}
   \doclass{Phonetics}
   \doclass{Punctuation}
   \doclass{SundaneseFull}
   \doclass{Symbols}
+  \doclass{SyriacFull}
   \doclass{Yi}
   \doclass{Other}
 }
@@ -563,6 +565,11 @@
   \do{SupplementalMathematicalOperators}
 }
 
+\def\MongolianFullClasses{
+  \do{Mongolian}
+    \do{MongolianSupplement}
+}
+
 \def\MyanmarFullClasses{
   \do{Myanmar}
   \do{MyanmarExtendedA}
@@ -608,6 +615,11 @@
   \do{SupplementalArrowsC}
   \do{SupplementalSymbolsAndPictographs}
   \do{TransportAndMapSymbols}
+}
+
+\def\SyriacFullClasses{
+  \do{Syriac}
+  \do{SyriacSupplement}
 }
 
 \def\YiClasses{
@@ -694,7 +706,6 @@
   \do{MeroiticHieroglyphs}
   \do{Miao}
   \do{Modi}
-  \do{Mongolian}
   \do{Mro}
   \do{Multani}
   \do{MusicalSymbols}
@@ -740,7 +751,6 @@
 %     SupplementaryPrivateUseAreaB (see below)
 %     SuttonSignWriting (see below)
   \do{SylotiNagri}
-  \do{Syriac}
   \do{Tagalog}
   \do{Tagbanwa}
   \do{Tags}
@@ -771,7 +781,6 @@
     \do{Duployan}
     \do{Marchen}
     \do{MasaramGondi}
-    \do{MongolianSupplement}
     \do{Newa}
     \do{Nushu}
     \do{OldItalic}
@@ -785,7 +794,6 @@
     \do{SupplementaryPrivateUseAreaA}
     \do{SupplementaryPrivateUseAreaB}
     \do{SuttonSignWriting}
-    \do{SyriacSupplement}
     \do{Tangut}
     \do{TangutComponents}
     \do{ZanabazarSquare}

--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -177,13 +177,13 @@
   \do{NumberForms}{"02150}{"0218F}
   \do{Ogham}{"01680}{"0169F}
   \do{OlChiki}{"01C50}{"01C7F}
-  \do{OldItalic}{"010300}{"01032F}
+%     OldItalic (see below)
   \do{OldPersian}{"0103A0}{"0103DF}
   \do{OpticalCharacterRecognition}{"02440}{"0245F}
   \do{Oriya}{"0B00}{"0B7F}
   \do{Osmanya}{"010480}{"0104AF}
   \do{PhagsPa}{"0A840}{"0A87F}
-  \do{PhaistosDisc}{"0101D0}{"0101FF}
+%     PhaistosDisc (see below)
   \do{Phoenician}{"010900}{"01091F}
   \do{PhoneticExtensions}{"01D00}{"01D7F}
   \do{PhoneticExtensionsSupplement}{"01D80}{"01DBF}
@@ -242,8 +242,8 @@
   \do{Lisu}{"0A4D0}{"0A4FF}
   \do{MeeteiMayek}{"0ABC0}{"0ABFF}
   \do{MyanmarExtendedA}{"0AA60}{"0AA7F}
-  \do{OldSouthArabian}{"010A60}{"010A7F}
-  \do{OldTurkic}{"010C00}{"010C4F}
+%     OldSouthArabian (see below)
+%     OldTurkic (see below)
   \do{RumiNumeralSymbols}{"010E60}{"010E7F}
   \do{Samaritan}{"0800}{"083F}
   \do{TaiTham}{"01A20}{"01AAF}
@@ -295,7 +295,7 @@
   \do{Mro}{"016A40}{"016A6F}
   \do{MyanmarExtendedB}{"0A9E0}{"0A9FF}
   \do{Nabataean}{"010880}{"0108AF}
-  \do{OldNorthArabian}{"010A80}{"010A9F}
+%     OldNorthArabian (see below)
   \do{OldPermic}{"010350}{"01037F}
   \do{OrnamentalDingbats}{"01F650}{"01F67F}
   \do{PahawhHmong}{"016B00}{"016B8F}
@@ -321,10 +321,15 @@
 %     SuttonSignWriting (see below)
 %
   \ifdefined\XeTeXinterwordspaceshaping
+    \do{Duployan}{"01BC00}{"01BC9F}
+    \do{OldItalic}{"010300}{"01032F}
+    \do{OldNorthArabian}{"010A80}{"010A9F}
+    \do{OldSouthArabian}{"010A60}{"010A7F}
+    \do{OldTurkic}{"010C00}{"010C4F}
+    \do{PhaistosDisc}{"0101D0}{"0101FF}
+    \do{ShorthandFormatControls}{"01BCA0}{"01BCAF}
     \do{SupplementaryPrivateUseAreaA}{"0F0000}{"0FFFFF}
     \do{SupplementaryPrivateUseAreaB}{"0100000}{"010FFFF}
-    \do{Duployan}{"01BC00}{"01BC9F}
-    \do{ShorthandFormatControls}{"01BCA0}{"01BCAF}
     \do{SuttonSignWriting}{"01D800}{"01DAAF}
   \fi
 }
@@ -638,12 +643,12 @@
   \do{Ogham}
   \do{OlChiki}
   \do{OldHungarian}
-  \do{OldItalic}
-  \do{OldNorthArabian}
+%     OldItalic (see below)
+%     OldNorthArabian (see below)
   \do{OldPermic}
   \do{OldPersian}
-  \do{OldSouthArabian}
-  \do{OldTurkic}
+%     OldSouthArabian (see below)
+%     OldTurkic (see below)
   \do{OpticalCharacterRecognition}
   \do{Oriya}
   \do{Osmanya}
@@ -651,7 +656,7 @@
   \do{Palmyrene}
   \do{PauCinHau}
   \do{PhagsPa}
-  \do{PhaistosDisc}
+%     PhaistosDisc (see below)
   \do{Phoenician}
   \do{PlayingCards}
   \do{PrivateUseArea}
@@ -702,10 +707,15 @@
   \do{YijingHexagramSymbols}
 %
   \ifdefined\XeTeXinterwordspaceshaping
+    \do{Duployan}
+    \do{OldItalic}
+    \do{OldNorthArabian}
+    \do{OldSouthArabian}
+    \do{OldTurkic}
+    \do{PhaistosDisc}
+    \do{ShorthandFormatControls}
     \do{SupplementaryPrivateUseAreaA}
     \do{SupplementaryPrivateUseAreaB}
-    \do{Duployan}
-    \do{ShorthandFormatControls}
     \do{SuttonSignWriting}
   \fi
 }

--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -381,17 +381,23 @@
 
 \def\ClassGroups{
   \doclass{Arabics}
+  \doclass{CanadianSyllabics}
+  \doclass{CherokeeFull}
   \doclass{Chinese}
   \doclass{CJK}
   \doclass{Cyrillics}
   \doclass{Diacritics}
+  \doclass{EthiopicFull}
+  \doclass{GeorgianFull}
   \doclass{Greek}
   \doclass{Korean}
   \doclass{Japanese}
   \doclass{Latin}
   \doclass{Mathematics}
+  \doclass{MyanmarFull}
   \doclass{Phonetics}
   \doclass{Punctuation}
+  \doclass{SundaneseFull}
   \doclass{Symbols}
   \doclass{Yi}
   \doclass{Other}
@@ -403,6 +409,16 @@
   \do{ArabicPresentationFormsA}
   \do{ArabicPresentationFormsB}
   \do{ArabicSupplement}
+}
+
+\def\CanadianSyllabics{
+  \do{UnifiedCanadianAboriginalSyllabics}
+  \do{UnifiedCanadianAboriginalSyllabicsExtended}
+}
+
+\def\CherokeeFullClasses{
+  \do{Cherokee}
+  \do{CherokeeSupplement}
 }
 
 \def\ChineseClasses{
@@ -485,6 +501,18 @@
   \do{SpacingModifierLetters}
 }
 
+\def\EthiopicFullClasses{
+  \do{Ethiopic}
+  \do{EthiopicExtended}
+  \do{EthiopicExtendedA}
+  \do{EthiopicSupplement}
+}
+
+\def\GeorgianFullClasses{
+  \do{Georgian}
+  \do{GeorgianSupplement}
+}
+
 \def\GreekClasses{
   \do{Coptic}
   \do{CopticEpactNumbers}
@@ -533,6 +561,12 @@
   \do{SupplementalMathematicalOperators}
 }
 
+\def\MyanmarFullClasses{
+  \do{Myanmar}
+  \do{MyanmarExtendedA}
+  \do{MyanmarExtendedB}
+}
+
 \def\PhoneticsClasses{
   \do{IPAExtensions}
   \do{PhoneticExtensions}
@@ -542,6 +576,11 @@
 \def\PunctuationClasses{
   \do{GeneralPunctuation}
   \do{SupplementalPunctuation}
+}
+
+\def\SundaneseFullClasses{
+  \do{Sundanese}
+  \do{SundaneseSupplement}
 }
 
 \def\SymbolsClasses{
@@ -598,8 +637,6 @@
   \do{Cham}
   \do{CaucasianAlbanian}
   \do{Chakma}
-  \do{Cherokee}
-  \do{CherokeeSupplement}
   \do{CommonIndicNumberForms}
   \do{Coptic}
   \do{CountingRodNumerals}
@@ -615,12 +652,6 @@
   \do{Elbasan}
   \do{EnclosedAlphanumerics}
   \do{EnclosedAlphanumericSupplement}
-  \do{Ethiopic}
-  \do{EthiopicExtended}
-  \do{EthiopicExtendedA}
-  \do{EthiopicSupplement}
-  \do{Georgian}
-  \do{GeorgianSupplement}
   \do{Gothic}
   \do{Grantha}
   \do{Gujarati}
@@ -665,9 +696,6 @@
   \do{Mro}
   \do{Multani}
   \do{MusicalSymbols}
-  \do{Myanmar}
-  \do{MyanmarExtendedA}
-  \do{MyanmarExtendedB}
   \do{Nabataean}
   \do{NewTaiLue}
   \do{NKo}
@@ -705,8 +733,6 @@
   \do{SinhalaArchaicNumbers}
   \do{SmallFormVariants}
   \do{SoraSompeng}
-  \do{Sundanese}
-  \do{SundaneseSupplement}
   \do{SuperscriptsAndSubscripts}
 %     SupplementaryPrivateUseAreaA (see below)
 %     SupplementaryPrivateUseAreaB (see below)
@@ -729,8 +755,6 @@
   \do{Tifinagh}
   \do{Tirhuta}
   \do{Ugaritic}
-  \do{UnifiedCanadianAboriginalSyllabics}
-  \do{UnifiedCanadianAboriginalSyllabicsExtended}
   \do{Vai}
   \do{VedicExtensions}
   \do{VerticalForms}
@@ -939,17 +963,24 @@
 % Available informal groups are:
 %
 %   - Arabics
+%   - CanadianSyllabics
+%   - CherokeeFull
 %   - Chinese (including bopomofo)
 %   - CJK (Chinese/Japanese/Korean)
 %   - Cyrillics
 %   - Diacritics
+%   - EthiopicFull
+%   - GeorgianFull
 %   - Greek
-%   - Japanese	(it is advised to set CJK first to a catch-all, then set Japanese for specifics)
+%   - Japanese (it is advised to set CJK first to a catch-all, then set
+%               Japanese for specifics)
 %   - Korean (=Hangul) (same comment as for Japanese)
 %   - Latin
 %   - Mathematics
+%   - MyanmarFull
 %   - Phonetics
 %   - Punctuation
+%   - SundaneseFull
 %   - Symbols
 %   - Yi
 %   - Other (I am not a fan of lump groups. I hope to un-lump most of it)

--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -989,11 +989,13 @@
 %   - Korean (=Hangul) (same comment as for Japanese)
 %   - Latin
 %   - Mathematics
+%   - MongolianFull
 %   - MyanmarFull
 %   - Phonetics
 %   - Punctuation
 %   - SundaneseFull
 %   - Symbols
+%   - SyriacFull
 %   - Yi
 %   - Other (I am not a fan of lump groups. I hope to un-lump most of it)
 %

--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -5,7 +5,7 @@
 %  automatically when a transition from a character from one unicode block to a
 %  character from another unicode block is encountered by XeTeX
 %
-%  Current compatibility should be Unicode 8.0.
+%  Current compatibility should be Unicode 10.0.
 %
 %  Credits:
 %   v2.1-2.2: Qing Lee, Werner Lemberg
@@ -318,6 +318,13 @@
   \do{Multani}{"011280}{"0112AF}
   \do{OldHungarian}{"010C80}{"010CFF}
   \do{SupplementalSymbolsAndPictographs}{"01F900}{"01F9FF}
+% Unicode 9.0 additions needed for classes
+  \do{CyrillicExtendedC}{"01C80}{"01C8F}
+  \do{GlagoliticSupplement}{"01E000}{"01E02F}
+  \do{IdeographicSymbolsAndPunctuation}{"016FE0}{"016FFF}
+% Unicode 10.0 additions needed for classes
+  \do{CJKUnifiedIdeographsExtensionF}{"02CEB0}{"02EBEF}
+  \do{KanaExtendedA}{"01B100}{"01B12F}
 %     SuttonSignWriting (see below)
 %
   \ifdefined\XeTeXinterwordspaceshaping
@@ -331,8 +338,24 @@
     \do{SupplementaryPrivateUseAreaA}{"0F0000}{"0FFFFF}
     \do{SupplementaryPrivateUseAreaB}{"0100000}{"010FFFF}
     \do{SuttonSignWriting}{"01D800}{"01DAAF}
+%   Unicode 9.0 additions
+    \do{Adlam}{"01E900}{"01E95F}
+    \do{Bhaiksuki}{"011C00}{"011C6F}
+    \do{Marchen}{"011C70}{"011CBF}
+    \do{MongolianSupplement}{"011660}{"01167F}
+    \do{Newa}{"011400}{"01147F}
+    \do{Osage}{"0104B0}{"0104FF}
+    \do{Tangut}{"017000}{"0187FF}
+    \do{TangutComponents}{"018800}{"018AFF}
+%   Unicode 10.0 additions
+    \do{MasaramGondi}{"011D00}{"011D5F}
+    \do{Nushu}{"01B170}{"01B2FF}
+    \do{Soyombo}{"011A50}{"011AAF}
+    \do{SyriacSupplement}{"0860}{"086F}
+    \do{ZanabazarSquare}{"011A00}{"011A4F}
   \fi
 }
+
 % ----------------------------------------------------------------------------
 %  Option handling lets the user turn off "load all" and selectively enable only those blocks
 %  they are interested in
@@ -398,9 +421,11 @@
   \do{CJKUnifiedIdeographsExtensionC}
   \do{CJKUnifiedIdeographsExtensionD}
   \do{CJKUnifiedIdeographsExtensionE}
+  \do{CJKUnifiedIdeographsExtensionF}
   \do{EnclosedCJKLettersAndMonths}
   \do{EnclosedIdeographicSupplement}
   \do{IdeographicDescriptionCharacters}
+  \do{IdeographicSymbolsAndPunctuation}
   \do{KangxiRadicals}
 }
 
@@ -420,6 +445,7 @@
   \do{CJKUnifiedIdeographsExtensionC}
   \do{CJKUnifiedIdeographsExtensionD}
   \do{CJKUnifiedIdeographsExtensionE}
+  \do{CJKUnifiedIdeographsExtensionF}
   \do{EnclosedCJKLettersAndMonths}
   \do{EnclosedIdeographicSupplement}
   \do{HalfwidthAndFullwidthForms}
@@ -430,18 +456,22 @@
   \do{HangulSyllables}
   \do{Hiragana}
   \do{IdeographicDescriptionCharacters}
+  \do{IdeographicSymbolsAndPunctuation}
+  \do{KanaSupplement}
+  \do{KanaExtendedA}
   \do{Kanbun}
   \do{KangxiRadicals}
   \do{Katakana}
   \do{KatakanaPhoneticExtensions}
-  \do{KanaSupplement}
 }
 
 \def\CyrillicsClasses{
   \do{Cyrillic}
   \do{CyrillicExtendedA}
   \do{CyrillicExtendedB}
+  \do{CyrillicExtendedC}
   \do{CyrillicSupplement}
+  \do{GlagoliticSupplement}
   \do{Glagolitic}
 }
 
@@ -474,11 +504,12 @@
   \do{CJKUnifiedIdeographs}
   \do{HalfwidthAndFullwidthForms}
   \do{Hiragana}
+  \do{KanaSupplement}
+  \do{KanaExtendedA}
   \do{Kanbun}
   \do{KangxiRadicals}
   \do{Katakana}
   \do{KatakanaPhoneticExtensions}
-  \do{KanaSupplement}
 }
 
 \def\LatinClasses{
@@ -707,16 +738,29 @@
   \do{YijingHexagramSymbols}
 %
   \ifdefined\XeTeXinterwordspaceshaping
+    \do{Adlam}
+    \do{Bhaiksuki}
     \do{Duployan}
+    \do{Marchen}
+    \do{MasaramGondi}
+    \do{MongolianSupplement}
+    \do{Newa}
+    \do{Nushu}
     \do{OldItalic}
     \do{OldNorthArabian}
     \do{OldSouthArabian}
     \do{OldTurkic}
+    \do{Osage}
     \do{PhaistosDisc}
     \do{ShorthandFormatControls}
+    \do{Soyombo}
     \do{SupplementaryPrivateUseAreaA}
     \do{SupplementaryPrivateUseAreaB}
     \do{SuttonSignWriting}
+    \do{SyriacSupplement}
+    \do{Tangut}
+    \do{TangutComponents}
+    \do{ZanabazarSquare}
   \fi
 }
 

--- a/ucharclasses.tex
+++ b/ucharclasses.tex
@@ -196,17 +196,23 @@
 
 			\begin{itemlist}
 				\item Arabics
+				\item CanadianSyllabics
+				\item CherokeeFull
 				\item Chinese
 				\item CJK
 				\item Cyrillics
 				\item Diacritics
+				\item EthiopicFull
+				\item GeorgianFull
 				\item Greek
 				\item Korean
 				\item Japanese
 				\item Latin
 				\item Mathematics
+				\item MyanmarFull
 				\item Phonetics
 				\item Punctuation
+				\item SundaneseFull
 				\item Symbols
 				\item Yi
 			\end{itemlist}
@@ -361,12 +367,13 @@
 
 	\section{Package options and Unicode blocks}
 
-		The following Unicode blocks are available for use in transition rules (corresponding to Unicode version 8.0), as well as for use as package options when you want ucharclasses to only load those classes that you know are used in your document.
+		The following Unicode blocks are available for use in transition rules (corresponding to Unicode version 10.0), as well as for use as package options when you want ucharclasses to only load those classes that you know are used in your document.
 
 		Starting with XeTeX version 0.99994, the number of \textbackslash XeTeXcharclass registers was extended from 256 to 4096; some not so important blocks are thus provided only for this and newer versions; in the list below, those blocks are put into parentheses.
 
 		\begin{multicols}{2}
 			\begin{itemlist}
+				\item (Adlam)
 				\item AegeanNumbers
 				\item Ahom
 				\item AlchemicalSymbols
@@ -391,6 +398,7 @@
 				\item BassaVah
 				\item Batak
 				\item Bengali
+				\item (Bhaiksuki)
 				\item BlockElements
 				\item Bopomofo
 				\item BopomofoExtended
@@ -419,6 +427,7 @@
 				\item CJKUnifiedIdeographsExtensionC
 				\item CJKUnifiedIdeographsExtensionD
 				\item CJKUnifiedIdeographsExtensionE
+				\item CJKUnifiedIdeographsExtensionF
 				\item CombiningDiacriticalMarks
 				\item CombiningDiacriticalMarksExtended
 				\item CombiningDiacriticalMarksForSymbols
@@ -436,6 +445,7 @@
 				\item Cyrillic
 				\item CyrillicExtendedA
 				\item CyrillicExtendedB
+				\item CyrillicExtendedC
 				\item CyrillicSupplement
 				\item Deseret
 				\item Devanagari
@@ -461,6 +471,7 @@
 				\item Georgian
 				\item GeorgianSupplement
 				\item Glagolitic
+				\item GlagoliticSupplement
 				\item Gothic
 				\item Grantha
 				\item GreekAndCoptic
@@ -478,12 +489,14 @@
 				\item Hebrew
 				\item Hiragana
 				\item IdeographicDescriptionCharacters
+				\item IdeographicSymbolsAndPunctuation
 				\item ImperialAramaic
 				\item InscriptionalPahlavi
 				\item InscriptionalParthian
 				\item IPAExtensions
 				\item Javanese
 				\item Kaithi
+				\item KanaExtendedA
 				\item KanaSupplement
 				\item Kanbun
 				\item KangxiRadicals
@@ -518,6 +531,8 @@
 				\item Malayalam
 				\item Mandaic
 				\item Manichaean
+				\item (Marchen)
+				\item (MasaramGondi)
 				\item MathematicalAlphanumericSymbols
 				\item MathematicalOperators
 				\item MeeteiMayek
@@ -535,6 +550,7 @@
 				\item Modi
 				\item ModifierToneLetters
 				\item Mongolian
+				\item (MongolianSupplement)
 				\item Mro
 				\item Multani
 				\item MusicalSymbols
@@ -542,27 +558,30 @@
 				\item MyanmarExtendedA
 				\item MyanmarExtendedB
 				\item Nabataean
+				\item (Newa)
 				\item NewTaiLue
 				\item NKo
 				\item NumberForms
+				\item (Nushu)
 				\item Ogham
 				\item OlChiki
 				\item OldHungarian
-				\item OldItalic
-				\item OldNorthArabian
+				\item (OldItalic)
+				\item (OldNorthArabian)
 				\item OldPermic
 				\item OldPersian
-				\item OldSouthArabian
-				\item OldTurkic
+				\item (OldSouthArabian)
+				\item (OldTurkic)
 				\item OpticalCharacterRecognition
 				\item Oriya
 				\item OrnamentalDingbats
+				\item (Osage)
 				\item Osmanya
 				\item PahawhHmong
 				\item Palmyrene
 				\item PauCinHau
 				\item PhagsPa
-				\item PhaistosDisc
+				\item (PhaistosDisc)
 				\item Phoenician
 				\item PhoneticExtensions
 				\item PhoneticExtensionsSupplement
@@ -582,6 +601,7 @@
 				\item SinhalaArchaicNumbers
 				\item SmallFormVariants
 				\item SoraSompeng
+				\item (Soyombo)
 				\item SpacingModifierLetters
 				\item Sundanese
 				\item SundaneseSupplement
@@ -597,6 +617,7 @@
 				\item (SuttonSignWriting)
 				\item SylotiNagri
 				\item Syriac
+				\item (SyriacSupplement)
 				\item Tagalog
 				\item Tagbanwa
 				\item Tags
@@ -606,6 +627,8 @@
 				\item TaiXuanJingSymbols
 				\item Takri
 				\item Tamil
+				\item (Tangut)
+				\item (TangutComponents)
 				\item Telugu
 				\item Thaana
 				\item Thai
@@ -623,6 +646,7 @@
 				\item YiRadicals
 				\item YiSyllables
 				\item YijingHexagramSymbols
+				\item (ZanabazarSquare)
 			\end{itemlist}
 		\end{multicols}
 
@@ -630,17 +654,23 @@
 
 		\begin{itemlist}
 			\item Arabics
+			\item CanadianSyllabics
+			\item CherokeeFull
 			\item Chinese
 			\item CJK
 			\item Cyrillics
 			\item Diacritics
+			\item EthiopicFull
+			\item GeorgianFull
 			\item Greek
 			\item Korean
 			\item Japanese
 			\item Latin
 			\item Mathematics
+			\item MyanmarFull
 			\item Phonetics
 			\item Punctuation
+			\item SundaneseFull
 			\item Symbols
 			\item Yi
 		\end{itemlist}

--- a/ucharclasses.tex
+++ b/ucharclasses.tex
@@ -209,11 +209,13 @@
 				\item Japanese
 				\item Latin
 				\item Mathematics
+				\item MongolianFull
 				\item MyanmarFull
 				\item Phonetics
 				\item Punctuation
 				\item SundaneseFull
 				\item Symbols
+				\item SyriacFull
 				\item Yi
 			\end{itemlist}
 
@@ -378,7 +380,7 @@
 				\item Ahom
 				\item AlchemicalSymbols
 				\item AlphabeticPresentationForms
-				\item AnatolianHieroglyphs
+				\item (AnatolianHieroglyphs)
 				\item AncientGreekMusicalNotation
 				\item AncientGreekNumbers
 				\item AncientSymbols
@@ -408,7 +410,7 @@
 				\item Buginese
 				\item Buhid
 				\item ByzantineMusicalSymbols
-				\item Carian
+				\item (Carian)
 				\item CaucasianAlbanian
 				\item Chakma
 				\item Cham
@@ -550,7 +552,7 @@
 				\item Modi
 				\item ModifierToneLetters
 				\item Mongolian
-				\item (MongolianSupplement)
+				\item MongolianSupplement
 				\item Mro
 				\item Multani
 				\item MusicalSymbols
@@ -617,7 +619,7 @@
 				\item (SuttonSignWriting)
 				\item SylotiNagri
 				\item Syriac
-				\item (SyriacSupplement)
+				\item SyriacSupplement
 				\item Tagalog
 				\item Tagbanwa
 				\item Tags
@@ -667,11 +669,13 @@
 			\item Japanese
 			\item Latin
 			\item Mathematics
+			\item MongolianFull
 			\item MyanmarFull
 			\item Phonetics
 			\item Punctuation
 			\item SundaneseFull
 			\item Symbols
+			\item SyriacFull
 			\item Yi
 		\end{itemlist}
 


### PR DESCRIPTION
This commit updates ucharclasses to Unicode version 10.0.

* Scripts new in Unicode 9.0 and 10.0 have been added, mostly for the new XeTeX engine only.
* The following scripts previously available for new XeTeX versions are now available for older XeTeX versions, too (we need them to define proper class collections): CyrillicExtendedC, GlagoliticSupplement, IdeographicSymbolsandPunctuation, MongolianSupplement, CJKUnifiedIdeographsExtensionF, KanaExtendedA, SyriacSupplement.
* The following scripts previously available for old XeTeX versions are now only available for newer XeTeX versions (to make room for the scripts mentioned in the previous item): Carian, OldItalic, PhaistosDisc, OldSouthArabian, OldTurkish, OldNorthArabian, AnatolianHieroglyphs.
* The following class collections have been added: CanadianSyllabics, CherokeeFull, EthiopicFull, GeorgianFull, MongolianFull, MyanmarFull, SundaneseFull, SyriacFull.