### PR TITLE
Unicode 16.0

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@
 
             ucharclasses package for XeLaTex
          --------------------------------------
-           Michiel Kamermans, v2.6, October 2022
+           Michiel Kamermans, v2.7, May 2024
 
 The brief
 ---------
@@ -63,6 +63,7 @@ Unicode Compatibility
 Changelog
 ---------
 
+ v2.7: Unicode 16 support, new class \EgyptianHieroglyphsFull
  v2.6: Unicode 15 support
  v2.5: Unicode 14 support
  v2.4: Unicode 11, 12, and 13 support
@@ -75,7 +76,7 @@ Changelog
 Contributors
 ------------
 
- v2.5-2.6: Werner Lemberg
+ v2.5-2.7: Werner Lemberg
  v2.4: Werner Lemberg, Shreeshrii
  v2.1-2.3: Qing Lee, Werner Lemberg
  v2.0: Enrico Gregorio

--- a/ucharclasses.sty
+++ b/ucharclasses.sty
@@ -5,16 +5,17 @@
 %  automatically when a transition from a character from one unicode block to a
 %  character from another unicode block is encountered by XeTeX
 %
-%  Current compatibility should be Unicode 15.0
+%  Current compatibility should be Unicode 16.0
 %
 %  Credits:
-%   v2.5-2.6: Werner Lemberg
+%   v2.5-2.7: Werner Lemberg
 %   v2.4: Werner Lemberg, Shreeshrii
 %   v2.1-2.3: Qing Lee, Werner Lemberg
 %   v2.0: Enrico Gregorio
 %   v1.0: Mike "Pomax" Kamermans
 %
 %  Significant updates:
+%   v2.7: Unicode 16 support, new class \EgyptianHieroglyphsFull
 %   v2.6: Unicode 15 support
 %   v2.5: Unicode 14 support
 %   v2.4: Unicode 13 support
@@ -28,7 +29,7 @@
 %
 % ----------------------------------------------------------------------------
 
-\ProvidesPackage{ucharclasses}[2022/10/20 v2.6.0 Unicode block character classes for XeLaTeX]
+\ProvidesPackage{ucharclasses}[2024/05/16 v2.7.0 Unicode block character classes for XeLaTeX]
 
 \newif\if@ucharclassverbose
 \DeclareOption{verbose}{\@ucharclassverbosetrue}
@@ -109,7 +110,7 @@
   \do{Cuneiform}{"012000}{"0123FF}
   \do{CuneiformNumbersAndPunctuation}{"012400}{"01247F}
   \do{CurrencySymbols}{"020A0}{"020CF}
-  \do{CypriotSyllabary}{"010800}{"01083F}
+%     CypriotSyllabary (see below)
   \do{Cyrillic}{"0400}{"04FF}
   \do{CyrillicExtendedA}{"02DE0}{"02DFF}
   \do{CyrillicExtendedB}{"0A640}{"0A69F}
@@ -244,9 +245,9 @@
   \do{EnclosedIdeographicSupplement}{"01F200}{"01F2FF}
   \do{HangulJamoExtendedA}{"0A960}{"0A97F}
   \do{HangulJamoExtendedB}{"0D7B0}{"0D7FF}
-  \do{ImperialAramaic}{"010840}{"01085F}
-  \do{InscriptionalPahlavi}{"010B60}{"010B7F}
-  \do{InscriptionalParthian}{"010B40}{"010B5F}
+%     ImperialAramaic (see below)
+%     InscriptionalPahlavi (see below)
+%     InscriptionalParthian (see below)
   \do{Javanese}{"0A980}{"0A9DF}
   \do{Kaithi}{"011080}{"0110CF}
   \do{Lisu}{"0A4D0}{"0A4FF}
@@ -334,6 +335,8 @@
 % Unicode 11.0 additions needed for classes
   \do{GeorgianExtended}{"01C90}{"01CBF}
 % Unicode 12.0 additions needed for classes
+  % The range was extended in Unicode 15.0
+  \do{EgyptianHieroglyphFormatControls}{"013430}{"01345F}
   \do{SmallKanaExtension}{"01B130}{"01B16F}
   \do{SymbolsAndPictographsExtendedA}{"01FA70}{"01FAFF}
 % Unicode 13.0 additions needed for classes
@@ -350,10 +353,15 @@
   \do{CJKUnifiedIdeographsExtensionH}{"031350}{"0323AF}
   \do{CyrillicExtendedD}{"01E030}{"01E08F}
   \do{DevanagariExtendedA}{"011B00}{"011B5F}
+% Unicode 16.0 additions needed for classes
+  \do{CJKUnifiedIdeographsExtensionI}{"02EBF0}{"02EE5F}
+  \do{EgyptianHieroglyphsExtendedA}{"013460}{"0143FF}
+  \do{MyanmarExtendedC}{"0116D0}{"0116FF}
 %
   \ifdefined\XeTeXinterwordspaceshaping
 %   Unicode 5.1 block definitions
     \do{Carian}{"0102A0}{"0102DF}
+    \do{CypriotSyllabary}{"010800}{"01083F}
     \do{Gothic}{"010330}{"01034F}
     \do{Kharoshthi}{"010A00}{"010A5F}
     \do{Lycian}{"010280}{"01029F}
@@ -363,6 +371,9 @@
     \do{SupplementaryPrivateUseAreaA}{"0F0000}{"0FFFFF}
     \do{SupplementaryPrivateUseAreaB}{"0100000}{"010FFFF}
 %   Unicode 5.2 additions
+    \do{ImperialAramaic}{"010840}{"01085F}
+    \do{InscriptionalPahlavi}{"010B60}{"010B7F}
+    \do{InscriptionalParthian}{"010B40}{"010B5F}
     \do{OldSouthArabian}{"010A60}{"010A7F}
     \do{OldTurkic}{"010C00}{"010C4F}
 %   Unicode 7.0 additions
@@ -407,8 +418,6 @@
     \do{OldSogdian}{"010F00}{"010F2F}
     \do{Sogdian}{"010F30}{"010F6F}
 %   Unicode 12.0 additions
-    % The range was extended in Unicode 15.0
-    \do{EgyptianHieroglyphFormatControls}{"013430}{"01345F}
     \do{Elymaic}{"010FE0}{"010FFF}
     \do{Nandinagari}{"0119A0}{"0119FF}
     \do{NyiakengPuachueHmong}{"01E100}{"01E14F}
@@ -434,6 +443,15 @@
     \do{KaktovikNumerals}{"01D2C0}{"01D2DF}
     \do{Kawi}{"011F00}{"011F5F}
     \do{NagMundari}{"01E4D0}{"01E4FF}
+%   Unicode 16.0 additions
+    \do{Garay}{"010D40}{"010D8F}
+    \do{GurungKhema}{"016100}{"01613F}
+    \do{KiratRai}{"016D40}{"016D7F}
+    \do{OlOnal}{"01E5D0}{"01E5FF}
+    \do{Sunuwar}{"011BC0}{"011BFF}
+    \do{SymbolsForLegacyComputingSupplement}{"01CC00}{"01CEBF}
+    \do{Todhri}{"0105C0}{"0105FF}
+    \do{TuluTigalari}{"011380}{"0113FF}
   \fi
 }
 
@@ -469,6 +487,7 @@
   \doclass{Cyrillics}
   \doclass{Devanagari}
   \doclass{Diacritics}
+  \doclass{EgyptianHieroglyphsFull}
   \doclass{EthiopicFull}
   \doclass{GeorgianFull}
   \doclass{Greek}
@@ -528,6 +547,7 @@
   \do{CJKUnifiedIdeographsExtensionF}
   \do{CJKUnifiedIdeographsExtensionG}
   \do{CJKUnifiedIdeographsExtensionH}
+  \do{CJKUnifiedIdeographsExtensionI}
   \do{EnclosedCJKLettersAndMonths}
   \do{EnclosedIdeographicSupplement}
   \do{IdeographicDescriptionCharacters}
@@ -603,6 +623,12 @@
   \do{SpacingModifierLetters}
 }
 
+\def\EgyptianHieroglyphFullClasses{
+  \do{EgyptianHieroglyphs}
+  \do{EgyptianHieroglyphFormatControls}
+  \do{EgyptianHieroglyphsExtendedA}
+}
+
 \def\EthiopicFullClasses{
   \do{Ethiopic}
   \do{EthiopicExtended}
@@ -676,6 +702,7 @@
   \do{Myanmar}
   \do{MyanmarExtendedA}
   \do{MyanmarExtendedB}
+  \do{MyanmarExtendedC}
 }
 
 \def\PhoneticsClasses{
@@ -773,7 +800,6 @@
   \do{DominoTiles}
 %     Duployan (see below)
   \do{EarlyDynasticCuneiform}
-  \do{EgyptianHieroglyphs}
   \do{Elbasan}
   \do{EnclosedAlphanumerics}
   \do{EnclosedAlphanumericSupplement}
@@ -894,7 +920,6 @@
     \do{DivesAkuru}
     \do{Dogra}
     \do{Duployan}
-    \do{EgyptianHieroglyphFormatControls}
     \do{Elymaic}
     \do{GeorgianExtended}
     \do{Gothic}
@@ -1137,6 +1162,7 @@
 %   - Cyrillics
 %   - Devanagari
 %   - Diacritics
+%   - EgyptianHieroglyphsFull
 %   - EthiopicFull
 %   - GeorgianFull
 %   - Greek

--- a/ucharclasses.tex
+++ b/ucharclasses.tex
@@ -63,7 +63,7 @@
 
 \begin{document}
 
-  \title{ucharclasses v2.6}
+  \title{ucharclasses v2.7}
   \author{Mike “Pomax” Kamermans}
   \date{\today}
   \maketitle
@@ -213,6 +213,7 @@
         \item Cyrillics
         \item Devanagari
         \item Diacritics
+        \item EgyptianHieroglyphsFull
         \item EthiopicFull
         \item GeorgianFull
         \item Greek
@@ -383,7 +384,7 @@
 
   \section{Package options and Unicode blocks}
 
-    The following Unicode blocks are available for use in transition rules (corresponding to Unicode version 15.0), as well as for use as package options when you want ucharclasses to only load those classes that you know are used in your document.
+    The following Unicode blocks are available for use in transition rules (corresponding to Unicode version 16.0), as well as for use as package options when you want ucharclasses to only load those classes that you know are used in your document.
 
     Starting with XeTeX version 0.99994 (available in TeXLive 2016), the number of \textbackslash XeTeXcharclass registers was extended from 256 to 4096; some not so important blocks are thus provided only for this and newer versions; in the list below, those blocks are put into parentheses.
 
@@ -450,6 +451,7 @@
         \item CJKUnifiedIdeographsExtensionF
         \item CJKUnifiedIdeographsExtensionG
         \item CJKUnifiedIdeographsExtensionH
+        \item CJKUnifiedIdeographsExtensionI
         \item CombiningDiacriticalMarks
         \item CombiningDiacriticalMarksExtended
         \item CombiningDiacriticalMarksForSymbols
@@ -463,7 +465,7 @@
         \item Cuneiform
         \item CuneiformNumbersAndPunctuation
         \item CurrencySymbols
-        \item CypriotSyllabary
+        \item (CypriotSyllabary)
         \item (CyproMinoan)
         \item Cyrillic
         \item CyrillicExtendedA
@@ -482,7 +484,8 @@
         \item (Duployan)
         \item (EarlyDynasticCuneiform)
         \item EgyptianHieroglyphs
-        \item (EgyptianHieroglyphFormatControls)
+        \item EgyptianHieroglyphFormatControls
+        \item EgyptianHieroglyphsExtendedA
         \item Elbasan
         \item (Elymaic)
         \item Emoticons
@@ -495,6 +498,7 @@
         \item EthiopicExtendedA
         \item EthiopicExtendedB
         \item EthiopicSupplement
+        \item (Garay)
         \item GeneralPunctuation
         \item GeometricShapes
         \item GeometricShapesExtended
@@ -510,6 +514,7 @@
         \item Gujarati
         \item (GunjalaGondi)
         \item Gurmukhi
+        \item (GurungKhema)
         \item HalfwidthAndFullwidthForms
         \item HangulCompatibilityJamo
         \item HangulJamo
@@ -523,10 +528,10 @@
         \item Hiragana
         \item IdeographicDescriptionCharacters
         \item IdeographicSymbolsAndPunctuation
-        \item ImperialAramaic
+        \item (ImperialAramaic)
         \item (IndicSiyaqNumbers)
-        \item InscriptionalPahlavi
-        \item InscriptionalParthian
+        \item (InscriptionalPahlavi)
+        \item (InscriptionalParthian)
         \item IPAExtensions
         \item Javanese
         \item Kaithi
@@ -547,6 +552,7 @@
         \item KhmerSymbols
         \item Khojki
         \item Khudawadi
+        \item (KiratRai)
         \item Lao
         \item LatinExtendedAdditional
         \item LatinExtendedA
@@ -601,6 +607,7 @@
         \item Myanmar
         \item MyanmarExtendedA
         \item MyanmarExtendedB
+        \item MyanmarExtendedC
         \item (Nabataean)
         \item (NagMundari)
         \item (Nandinagari)
@@ -621,6 +628,7 @@
         \item (OldSouthArabian)
         \item (OldTurkic)
         \item (OldUighur)
+        \item (OlOnal)
         \item OpticalCharacterRecognition
         \item Oriya
         \item OrnamentalDingbats
@@ -657,6 +665,7 @@
         \item SpacingModifierLetters
         \item Sundanese
         \item SundaneseSupplement
+        \item (Sunuwar)
         \item SuperscriptsAndSubscripts
         \item SupplementalArrowsA
         \item SupplementalArrowsB
@@ -670,6 +679,7 @@
         \item SylotiNagri
         \item SymbolsAndPictographsExtendedA
         \item (SymbolsForLegacyComputing)
+        \item (SymbolsForLegacyComputingSupplement)
         \item Syriac
         \item SyriacSupplement
         \item Tagalog
@@ -692,8 +702,10 @@
         \item Tibetan
         \item Tifinagh
         \item Tirhuta
+        \item (Todhri)
         \item (Toto)
         \item TransportAndMapSymbols
+        \item (TuluTigalari)
         \item Ugaritic
         \item UnifiedCanadianAboriginalSyllabics
         \item UnifiedCanadianAboriginalSyllabicsExtended


### PR DESCRIPTION
* New class `\EgyptianHieroglyphsFull`.

* Move the following scripts to the block for newer XeTeX versions since we need slots for extending existing classes:

    CypriotSyllabary
    ImperialAramaic
    InscriptionalPahlavi
    InscriptionalParthian

* Updates for version 2.7.